### PR TITLE
Update runtime to 25.08

### DIFF
--- a/com.xnview.XnViewMP.yaml
+++ b/com.xnview.XnViewMP.yaml
@@ -1,15 +1,8 @@
 app-id: com.xnview.XnViewMP
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: xnview
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    version: '24.08'
-    directory: lib/ffmpeg
-    add-ld-path: .
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 finish-args:
   # X11 + XShm access
   - --share=ipc


### PR DESCRIPTION
The ffmpeg extension is now installed and included with the runtime. Opening HEIF files works fine.